### PR TITLE
Add scripts for video and image format conversion

### DIFF
--- a/apps/website/scripts/image/convert_to_webp.sh
+++ b/apps/website/scripts/image/convert_to_webp.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Function to display usage instructions
+usage() {
+  echo "Usage: $0 [--quality <quality>]"
+  echo "Convert all images in the current directory to WebP format."
+  echo
+  echo "Options:"
+  echo "  --quality     Compression quality (optional, default is 75)"
+  exit 1
+}
+
+# Default quality
+QUALITY=75
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --quality)
+      if [[ -z "$2" || "$2" =~ ^- ]]; then
+        echo "Error: Missing or invalid value for --quality option."
+        usage
+      fi
+      QUALITY="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      usage
+      ;;
+  esac
+done
+
+# Output directory for converted images
+OUTPUT_DIR="./converted/"
+
+# Check if there are image files in the current directory
+shopt -s nullglob
+FILES=(*.{jpg,jpeg,png})
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  echo "No matching image files found in the current directory. Please ensure there are '.jpg', '.jpeg', or '.png' files present."
+  exit 1
+fi
+shopt -u nullglob
+
+# Ensure the output directory exists
+if [[ ! -d "$OUTPUT_DIR" ]]; then
+  mkdir -p "$OUTPUT_DIR"
+fi
+
+# Process each image file
+for INPUT in "${FILES[@]}"; do
+  # Extract filename and create output WebP file
+  FILENAME=$(basename "$INPUT")
+  BASENAME="${FILENAME%.*}" # Strip extension
+  OUTPUT_FILE="$OUTPUT_DIR/${BASENAME}.webp"
+
+  # Convert image to WebP
+  echo "Converting $INPUT to $OUTPUT_FILE with quality $QUALITY..."
+  cwebp -q "$QUALITY" "$INPUT" -o "$OUTPUT_FILE"
+
+  # Check for success
+  if [[ $? -eq 0 ]]; then
+    echo "Conversion completed: $OUTPUT_FILE"
+  else
+    echo "Error: Conversion failed for $INPUT."
+  fi
+done
+
+echo "All images processed."

--- a/apps/website/scripts/video/convert_to_web_video_formats.sh
+++ b/apps/website/scripts/video/convert_to_web_video_formats.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+# Function to display usage instructions
+usage() {
+  echo "Usage: $0 [--h264] [--vp9] [--av1] [--h265]"
+  echo "Convert all video files in the current directory to specified Web video formats."
+  echo
+  echo "Options:"
+  echo "  --h264     Generate H.264 codec videos (MP4 container)."
+  echo "  --vp9      Generate VP9 codec videos (WebM container)."
+  echo "  --av1      Generate AV1 codec videos (MP4 container)."
+  echo "  --h265     Generate H.265 codec videos (MP4 container, two variants: hvc1 and hev1)."
+  echo "By default, all formats are generated if no specific options are provided."
+  exit 1
+}
+
+# Output directory for converted videos
+OUTPUT_DIR="./converted/"
+
+# Default flags to generate all formats
+GENERATE_H264=false
+GENERATE_VP9=false
+GENERATE_AV1=false
+GENERATE_H265=false
+
+# Parse command-line arguments
+if [[ "$#" -eq 0 ]]; then
+  # If no arguments are provided, enable all formats by default
+  GENERATE_H264=true
+  GENERATE_VP9=true
+  GENERATE_AV1=true
+  GENERATE_H265=true
+else
+  # Process arguments to enable specific formats
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --h264)
+        GENERATE_H264=true
+        shift
+        ;;
+      --vp9)
+        GENERATE_VP9=true
+        shift
+        ;;
+      --av1)
+        GENERATE_AV1=true
+        shift
+        ;;
+      --h265)
+        GENERATE_H265=true
+        shift
+        ;;
+      *)
+        echo "Unknown option: $1"
+        usage
+        ;;
+    esac
+  done
+fi
+
+# Check if there are video files in the current directory
+shopt -s nullglob
+FILES=(*.{mp4,mkv,mov})
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  echo "No matching video files found in the current directory. Please ensure there are '.mp4', '.mkv', or '.mov' files present."
+  exit 1
+fi
+shopt -u nullglob
+
+# Process each video file
+for INPUT in "${FILES[@]}"; do
+  # Ensure the output directory exists
+  if [[ ! -d "$OUTPUT_DIR" ]]; then
+    mkdir -p "$OUTPUT_DIR"
+  fi
+
+  # Extract filename and create output file names
+  FILENAME=$(basename "$INPUT")
+  BASENAME="${FILENAME%.*}" # Strip extension
+
+  echo "Processing $INPUT..."
+
+  # Convert to H.264 format if enabled
+  if [[ "$GENERATE_H264" == true ]]; then
+    ffmpeg -i "$INPUT" -vf "scale=1920:1080" -c:v libx264 -preset slow -crf 23 -an "$OUTPUT_DIR/${BASENAME}_h264.mp4" &&
+    echo "Successfully converted to H.264: ${BASENAME}_h264.mp4"
+  fi
+
+  # Convert to VP9 format if enabled
+  if [[ "$GENERATE_VP9" == true ]]; then
+    ffmpeg -i "$INPUT" -vf "scale=1920:1080" -c:v libvpx-vp9 -b:v 0 -crf 30 -an "$OUTPUT_DIR/${BASENAME}_vp9.webm" &&
+    echo "Successfully converted to VP9: ${BASENAME}_vp9.webm"
+  fi
+
+  # Convert to AV1 format if enabled
+  if [[ "$GENERATE_AV1" == true ]]; then
+    ffmpeg -i "$INPUT" -vf "scale=1920:1080" -c:v libaom-av1 -crf 30 -b:v 0 -an "$OUTPUT_DIR/${BASENAME}_av1.mp4" &&
+    echo "Successfully converted to AV1: ${BASENAME}_av1.mp4"
+  fi
+
+  # Convert to H.265 formats if enabled
+  if [[ "$GENERATE_H265" == true ]]; then
+    ffmpeg -i "$INPUT" -vf "scale=1920:1080" -c:v libx265 -preset slow -crf 28 -tag:v hvc1 -an "$OUTPUT_DIR/${BASENAME}_h265_hvc1.mp4" &&
+    echo "Successfully converted to H.265 (hvc1): ${BASENAME}_h265_hvc1.mp4"
+
+    ffmpeg -i "$INPUT" -vf "scale=1920:1080" -c:v libx265 -preset slow -crf 28 -tag:v hev1 -an "$OUTPUT_DIR/${BASENAME}_h265_hev1.mp4" &&
+    echo "Successfully converted to H.265 (hev1): ${BASENAME}_h265_hev1.mp4"
+  fi
+
+  # Check the success of the last command and handle errors
+  if [[ $? -eq 0 ]]; then
+    echo "Requested formats successfully created for $INPUT."
+  else
+    echo "Error: Conversion failed for $INPUT."
+  fi
+done
+
+echo "All videos processed."


### PR DESCRIPTION
Introduce `convert_to_web_video_formats.sh` to process videos into H.264, VP9, AV1, and H.265 formats, and `convert_to_webp.sh` to convert images to WebP format. Both scripts handle batch processing, include error handling, and support customizable options (e.g., codec selection and image quality).